### PR TITLE
Add support for shorter format option

### DIFF
--- a/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/GradleVersioningExtension.kt
+++ b/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/GradleVersioningExtension.kt
@@ -32,6 +32,15 @@ interface GradleVersioningExtension {
     val branches: SetProperty<Regex>
 
     /**
+     * Controls whether to use `####.##.##` or `##.##.##` format.
+     * Note that shorter format makes assumption that versions
+     * are published within the same century.
+     *
+     * Default is `false`.
+     */
+    val useShorterFormat: Property<Boolean>
+
+    /**
      * Custom VCS message template, default is 'Version: %s'.
      */
     val commitTemplate: Property<String>

--- a/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/GradleVersioningPlugin.kt
+++ b/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/GradleVersioningPlugin.kt
@@ -25,6 +25,7 @@ class GradleVersioningPlugin : Plugin<Project> {
                 autoPush.convention(false)
                 variants.convention(setOf(""))
                 branches.convention(emptySet())
+                useShorterFormat.convention(false)
                 commitTemplate.convention("Version: %s")
             }
 
@@ -53,6 +54,7 @@ class GradleVersioningPlugin : Plugin<Project> {
     ) {
         val actions = extension.actions.get()
         val file = extension.versionCatalog.asFile.get()
+        val useShorterFormat = extension.useShorterFormat.get()
 
         if (!extension.versionCatalog.isPresent) {
             println("Version catalog property is not configured")
@@ -66,9 +68,13 @@ class GradleVersioningPlugin : Plugin<Project> {
         if (vcsContent.isEmpty()) {
             println("No version catalog is found, creating new one: $vcsPath")
 
-            val newVersion = CalendarVersion.generate(now, revision = 1)
+            val newVersion = CalendarVersion.create(now, revision = 1)
             val newCode = 1L
-            val newContent = VersionCatalogManager.serialize(newVersion, newCode)
+            val newContent = VersionCatalogManager.serialize(
+                version = newVersion,
+                code = newCode,
+                useShorterFormat = useShorterFormat
+            )
             file.writeText(newContent)
 
             val comment = extension
@@ -82,7 +88,8 @@ class GradleVersioningPlugin : Plugin<Project> {
             val newCode = prevCode + 1
             val newContent = VersionCatalogManager.serialize(
                 version = prevVersion.increment(now),
-                code = newCode
+                code = newCode,
+                useShorterFormat = useShorterFormat
             )
             file.writeText(newContent)
 
@@ -105,6 +112,7 @@ class GradleVersioningPlugin : Plugin<Project> {
         val actions = extension.actions.get()
         val branch = actions.getBranchName()
         val branches = extension.branches.get()
+        val shortFormat = extension.useShorterFormat.get()
 
         if (branches.isNotEmpty() &&
             branches.none { it.matches(branch) }
@@ -119,8 +127,8 @@ class GradleVersioningPlugin : Plugin<Project> {
         val version = if (headTags.isNotEmpty()) {
             val headVersions = buildMap {
                 for (tag in headTags) {
-                    CalendarVersion.parse(tag).onSuccess {
-                        put(tag.substringAfter('-', ""), it)
+                    CalendarVersion.parse(now, tag).onSuccess {
+                        put(tag.substringAfter(CalendarVersion.SuffixSeparator, ""), it)
                     }
                 }
             }
@@ -137,11 +145,8 @@ class GradleVersioningPlugin : Plugin<Project> {
         } else {
             calendarVersionFrom(latestTag, now)
         }
-        val suffix = variant
-            .takeUnless(String?::isNullOrBlank)
-            ?.let { "-$it" }
-            .orEmpty()
-        val versionTag = version.toString() + suffix
+        val suffix = variant.takeUnless(String?::isNullOrBlank)
+        val versionTag = version.formatVersion(shortFormat, suffix)
 
         actions.addTag(versionTag)
 
@@ -154,8 +159,8 @@ class GradleVersioningPlugin : Plugin<Project> {
         previousTag: String,
         pointInTime: LocalDateTime
     ) = CalendarVersion
-        .parse(previousTag)
+        .parse(pointInTime, previousTag)
         .getOrNull()
         ?.increment(pointInTime)
-        ?: CalendarVersion.generate(pointInTime, revision = 1)
+        ?: CalendarVersion.create(pointInTime, revision = 1)
 }

--- a/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/VersionCatalogManager.kt
+++ b/plugin-build/versioning/src/main/java/io/github/anvell/versioning/gradle/plugin/VersionCatalogManager.kt
@@ -3,6 +3,8 @@ package io.github.anvell.versioning.gradle.plugin
 import io.github.anvell.versioning.gradle.plugin.models.CalendarVersion
 import org.gradle.api.GradleException
 import org.tomlj.Toml
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 private const val GroupLabel = "versions"
 private const val VersionLabel = "name"
@@ -12,22 +14,26 @@ internal object VersionCatalogManager {
     fun deserialize(
         input: String
     ): Pair<CalendarVersion, Long> = with(Toml.parse(input)) {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
         val versionName = getString(listOf(GroupLabel, VersionLabel))
             ?: throw GradleException("Version name is not specified")
         val versionCode = getString(listOf(GroupLabel, CodeLabel))
             ?.toLongOrNull()
             ?: throw GradleException("Version code is not specified correctly")
-        val version = CalendarVersion.parse(versionName).getOrThrow()
+        val version = CalendarVersion
+            .parse(now, versionName)
+            .getOrThrow()
 
         version to versionCode
     }
 
     fun serialize(
         version: CalendarVersion,
-        code: Long
+        code: Long,
+        useShorterFormat: Boolean
     ) = buildString {
         appendLine("[$GroupLabel]")
-        appendLine("$VersionLabel = \"$version\"")
+        appendLine("$VersionLabel = \"${version.formatVersion(useShorterFormat)}\"")
         appendLine("$CodeLabel = \"$code\"")
     }
 }

--- a/plugin-build/versioning/src/test/java/io/github/anvell/versioning/gradle/plugin/CalendarVersionTest.kt
+++ b/plugin-build/versioning/src/test/java/io/github/anvell/versioning/gradle/plugin/CalendarVersionTest.kt
@@ -1,0 +1,40 @@
+package io.github.anvell.versioning.gradle.plugin
+
+import io.github.anvell.versioning.gradle.plugin.models.CalendarVersion
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDateTime
+
+class CalendarVersionTest {
+
+    @Test
+    fun `Short version format is respected`() {
+        val dateTime = LocalDateTime.of(2024, 1, 10, 12, 0)
+        val version = CalendarVersion
+            .parse(dateTime, "2047.01.10")
+            .getOrThrow()
+
+        assertEquals("2047.01.10", version.formatVersion(false))
+        assertEquals("47.01.10", version.formatVersion(true))
+    }
+
+    @Test
+    fun `When year value is short it's expanded to full`() {
+        val dateTime = LocalDateTime.of(2024, 1, 10, 12, 0)
+        val version = CalendarVersion
+            .parse(dateTime, "24.01.10")
+            .getOrThrow()
+
+        assertEquals("2024.01.10", version.formatVersion(false))
+        assertEquals("24.01.10", version.formatVersion(true))
+    }
+
+    @Test
+    fun `Short major is expanded when value is incremented`() {
+        val dateTime = LocalDateTime.of(2024, 1, 10, 12, 0)
+        val version = CalendarVersion(24, 1, 10).increment(dateTime)
+
+        assertEquals("2024.01.11", version.formatVersion(false))
+        assertEquals("24.01.11", version.formatVersion(true))
+    }
+}


### PR DESCRIPTION
## Description
Add support for shorter format option.

## Motivation and Context
In some cases default CalVer is too long, this feature provides alternative version.
